### PR TITLE
fix capitalisation typo in img files paths

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,7 +6,7 @@
 
 body {
   margin: -15px 0 0 -15px;
-  background: url(../assets/under-construction-assets/triangle.svg);
+  background: url(../Assets/under-construction-assets/triangle.svg);
   background-size: contain;
   background-repeat: no-repeat;
   background-position: right bottom;

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
           </div>
 
           <div class="image-container col-xs-6">
-            <img src="assets/under-construction-assets/my-code-dog.png" />
+            <img src="Assets/under-construction-assets/my-code-dog.png" />
           </div>
 
         </div>


### PR DESCRIPTION
Images on previous merge only display on local server. This PR aims to correct that.

I _think_ this error is due to capitalisation typo in image file paths (gh pages served by Linux servers, so path is case sensitive)